### PR TITLE
fix: improve reset mower blades return data

### DIFF
--- a/aiorobonect/client.py
+++ b/aiorobonect/client.py
@@ -205,4 +205,4 @@ class RobonectClient:
     async def async_reset_blades(self) -> bool:
         """Reset the mower blades."""
         result = await self.async_cmd("reset_blades")
-        return result
+        return {"reset_blades": result}


### PR DESCRIPTION
<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
<!-- walkthrough_start -->

## Walkthrough

The `async_reset_blades` method in the `aiorobonect/client.py` file has been updated to enhance its output. Previously returning a simple boolean, it now returns a dictionary that includes a key mapped to the result of the blade reset operation. This change provides a more informative and expandable structure for the method's output while maintaining its core functionality.

## Changes

| File                            | Change Summary                                                                                   |
|---------------------------------|-------------------------------------------------------------------------------------------------|
| `aiorobonect/client.py`        | Changed `async_reset_blades` return type from `bool` to `dict` for more descriptive output.    |

## Sequence Diagram(s)

```mermaid
sequenceDiagram
    participant User
    participant Mower
    User->>Mower: Request to reset blades
    Mower->>Mower: Execute reset operation
    Mower-->>User: Return {"reset_blades": success}
```


<!-- walkthrough_end --><!-- This is an auto-generated comment: raw summary by coderabbit.ai -->

## Summary of changes

The diff modifies the `async_reset_blades` method in the `aiorobonect/client.py` file. Previously, this method returned a boolean value indicating the success of the blade reset operation. The change alters the return type to a dictionary containing the key `"reset_blades"` mapped to the result of the command execution. This adjustment enhances the method's output by providing a more descriptive structure, allowing for potential expansion in the future to include additional details about the command's execution without changing the method signature. The overall functionality remains focused on resetting the mower blades, but the output now encapsulates the result in a more informative format.



## Alterations to the declarations of exported or public entities

- `async def async_reset_blades(self) -> bool` in `aiorobonect/client.py` → `async def async_reset_blades(self) -> dict` in `aiorobonect/client.py`
