### PR TITLE
fix: change ext command into equipment

### DIFF
--- a/aiorobonect/client.py
+++ b/aiorobonect/client.py
@@ -83,7 +83,7 @@ class RobonectClient:
         if params is None:
             params = ""
         else:
-            if command == "ext":
+            if command == "equipment":
                 ext = params.pop("ext")
             params = urllib.parse.urlencode(params)
 
@@ -96,7 +96,7 @@ class RobonectClient:
         def create_url(scheme):
             if command == "reset_blades":
                 return f"{scheme}://{self.host}/?btexe="
-            if command == "ext":
+            if command == "equipment":
                 return f"{scheme}://{self.host}/{ext}?{params}"
             return f"{scheme}://{self.host}/json?cmd={command}&{params}"
 
@@ -145,7 +145,7 @@ class RobonectClient:
                 await self.client_close()
                 return {"successful": True}
             result_text = response.text
-            if command == "ext":
+            if command == "equipment":
                 await self.client_close()
                 if "The changes were successfully applied" in result_text:
                     return {"successful": True}


### PR DESCRIPTION
<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
<!-- walkthrough_start -->

## Walkthrough
The changes in this pull request involve updating the command handling logic in the `async_cmd` method of the `aiorobonect/client.py` file. The command identifier "ext" has been replaced with "equipment" throughout the code, affecting parameter handling, URL creation, and response handling. This standardization ensures consistent terminology in the command processing.

## Changes

| Files                          | Change Summary                                                                                   |
|--------------------------------|-------------------------------------------------------------------------------------------------|
| aiorobonect/client.py         | Updated command handling logic in `async_cmd` method to replace "ext" with "equipment".       |

## Possibly related PRs
- #113: The changes in this PR also modify the `async_cmd` method in `aiorobonect/client.py`, specifically handling the "ext" command, which is directly related to the command handling logic being updated in the main PR.